### PR TITLE
fix: dont batch requests to s3 (yet)

### DIFF
--- a/.example.dev.vars
+++ b/.example.dev.vars
@@ -1,0 +1,8 @@
+# Hoverboard dev secrets
+
+# stringified dev peerid json
+PEER_ID_JSON='{"id":"12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ","privKey":"CAESQAyByThzp930nIDnJgz/jeuI/nr9njEaE25v9AhWgjBJe+aR6KPr8lT60H2MA3ItZF8t37H8PVa8yB4Cp61/pLo=","pubKey":"CAESIHvmkeij6/JU+tB9jANyLWRfLd+x/D1WvMgeAqetf6S6"}'
+
+# api keys for dynamo and s3
+AWS_SECRET_ACCESS_KEY=
+AWS_ACCESS_KEY_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .wrangler
+.dev.vars
+.env

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An IPFS Bitswap Peer in Cloudflare Workers
 
 Install `node` >= 18, and `wrangler` >= 3
 
+Copy `.example.dev.vars` to `.dev.vars` and set the AWS access keys vars.
+
 Run `npm start` to start a local dev server
 
 ```sh
@@ -14,11 +16,27 @@ $ npm start
 [mf:inf] Ready on http://127.0.0.1:8787/
 ```
 
-Run `npm run dial` to make a test connection to your local dev server
+`curl` the worker url to get your multiaddr
+
+```sh
+❯ curl http://127.0.0.1:8787/
+⁂ hoverboard v0.0.0 /ip4/127.0.0.1/tcp/8787/ws/p2p/12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ
+```
+
+Run `example/dial.js` to make a test connection to your local dev server
 
 ```
-npm run dial
-Connected to hoverboard 🛹 /ip4/127.0.0.1/tcp/8787/ws/p2p/Qmcv3CsJAN8ptXR8vm5a5GRrzkHGjaEUF9cQRGzYptMwzp
+$ node example/dial.js /ip4/127.0.0.1/tcp/8787/ws/p2p/12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ
+Connected to hoverboard 🛹 /ip4/127.0.0.1/tcp/8787/ws/p2p/12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ
+``` 
+
+Run `example/bitswap.js` to bitswap some blocks from staging, or pass your local multiaddr to try against dev.
+
+```
+node example/bitswap.js
+node loads.js
+Connecting to /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
+fetching bafybeicm3skx7ps2bwkh56l3mirh3hu4hmkfttfwjkmk4cr25sxtf2jmby
 ``` 
 
 ## Secrets

--- a/example/bitswap.js
+++ b/example/bitswap.js
@@ -1,6 +1,5 @@
 import { multiaddr } from '@multiformats/multiaddr'
 import * as Dagula from 'dagula/p2p.js'
-import { CID } from 'multiformats/cid'
 
 /**
  * Fetch cids via bitswap
@@ -15,7 +14,7 @@ import { CID } from 'multiformats/cid'
  * $ curl https://hoverboard-staging.dag.haus
  * ⁂ hoverboard v0.0.0 /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
  *
- * $ node loads.js [multiaddr] [cid1...]
+ * $ node bitswap.js [multiaddr] [cid1...]
  * Connecting to /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
  * Fetching bafybeicm3skx7ps2bwkh56l3mirh3hu4hmkfttfwjkmk4cr25sxtf2jmby
  * ```

--- a/example/dial.js
+++ b/example/dial.js
@@ -6,16 +6,24 @@ import { createLibp2p } from 'libp2p'
 import { mplex } from '@libp2p/mplex'
 
 /**
- * Run the `wranger dev` then run this to connect to the worker via libp2p
+ * Dial a libp2p node
+ *
+ * Run the `wrangler dev` then curl the worker url to get the multiaddr.
+ * Set secrets like PEER_ID_JSON in .dev.vars per the readme
  *
  * ```sh
- * $ node dial.js [worker url]
+ * curl https://hoverboard-staging.dag.haus
+ * ⁂ hoverboard v0.0.0 /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
+ * ```
+ *
+ * Usage:
+ * ```sh
+ * $ node dial.js /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
  * ```
  */
 
-const { hostname, port } = new URL(process.argv[2] ?? 'http://127.0.0.1:8787/')
-const PEER_ID = 'Qmcv3CsJAN8ptXR8vm5a5GRrzkHGjaEUF9cQRGzYptMwzp'
-const PEER_ADDR = multiaddr(`/ip4/${hostname}/tcp/${port}/ws/p2p/${PEER_ID}`)
+const peer = multiaddr(process.argv[2] ?? '/dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs')
+console.log(`Connecting to ${peer}`)
 
 const dialer = await createLibp2p({
   connectionEncryption: [noise()],
@@ -26,8 +34,7 @@ const dialer = await createLibp2p({
   }
 })
 
-// dialer.addEventListener('peer:identify', console.log)
-const peer = await dialer.dial(PEER_ADDR)
-console.log('Connected to hoverboard 🛹', peer.remoteAddr.toString())
-await dialer.hangUp(PEER_ADDR)
+const conn = await dialer.dial(peer)
+console.log('Connected to hoverboard 🛹', conn.remoteAddr.toString())
+await dialer.hangUp(peer)
 await dialer.stop()

--- a/example/loads.js
+++ b/example/loads.js
@@ -1,0 +1,52 @@
+import { multiaddr } from '@multiformats/multiaddr'
+import * as Dagula from 'dagula/p2p.js'
+import { CID } from 'multiformats/cid'
+
+/**
+ * Fetch cids via bitswap
+ *
+ * NOTE:
+ * - Run the `wrangler dev` then curl the worker url to get the multiaddr.
+ * - Set secrets like PEER_ID_JSON in .dev.vars per the readme
+ * - You can only fetch CIDs that are available in the env (staging||production) that you are connecting to
+
+ * Usage:
+ * ```sh
+ * $ curl https://hoverboard-staging.dag.haus
+ * ⁂ hoverboard v0.0.0 /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
+ *
+ * $ node loads.js [multiaddr] [cid1...]
+ * Connecting to /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
+ * Fetching bafybeicm3skx7ps2bwkh56l3mirh3hu4hmkfttfwjkmk4cr25sxtf2jmby
+ * ```
+ */
+
+const peer = multiaddr(process.argv[2] ?? '/dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs')
+console.log(`Connecting to ${peer}`)
+
+const libp2p = await Dagula.getLibp2p()
+const dagula = await Dagula.fromNetwork(libp2p, { peer })
+
+let cids = process.argv.slice(3)
+if (cids.length === 0) {
+  // ISS 4K Crew Earth Observations~orig.mov 328MiB
+  cids = ['bafybeicm3skx7ps2bwkh56l3mirh3hu4hmkfttfwjkmk4cr25sxtf2jmby']
+}
+console.log(`Fetching ${cids[0]}`)
+
+let count = 0
+let byteCount = 0
+for (const cid of cids) {
+  let blocksInDag = 0
+  for await (const block of dagula.get(cid)) {
+    const i = `${++count}`.padStart(4, '0')
+    byteCount += block.bytes.length
+    console.log(`${i} ${cid} -> ${block.cid} (${block.bytes.length} bytes, ${++blocksInDag} blocks in dag)`)
+  }
+}
+console.log('bytes received', byteCount)
+console.log('blocks received', count)
+console.log('Stopping libp2p')
+await libp2p.stop()
+
+console.log('done')

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@chainsafe/libp2p-noise": "^12.0.1",
         "@libp2p/mplex": "^8.0.4",
         "@libp2p/peer-id-factory": "^2.0.4",
+        "@multiformats/uri-to-multiaddr": "^7.0.0",
         "cf-libp2p-ws-transport": "^1.1.1",
         "events": "^3.3.0",
         "libp2p": "^0.45.9",
@@ -3655,6 +3656,45 @@
         "multiformats": "^12.0.1",
         "murmurhash3js-revisited": "^3.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/uri-to-multiaddr": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/uri-to-multiaddr/-/uri-to-multiaddr-7.0.0.tgz",
+      "integrity": "sha512-mB/I4znETEZA/PmflXmnjWj3ENcyJg6Yv3EQQbIdA5n9fJ43c58uMF2Ew7yXtl0Wxt4d1pAVFA6fki2xFrHGew==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^11.0.0",
+        "is-ip": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/uri-to-multiaddr/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/uri-to-multiaddr/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -17149,6 +17189,35 @@
       "requires": {
         "multiformats": "^12.0.1",
         "murmurhash3js-revisited": "^3.0.0"
+      }
+    },
+    "@multiformats/uri-to-multiaddr": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/uri-to-multiaddr/-/uri-to-multiaddr-7.0.0.tgz",
+      "integrity": "sha512-mB/I4znETEZA/PmflXmnjWj3ENcyJg6Yv3EQQbIdA5n9fJ43c58uMF2Ew7yXtl0Wxt4d1pAVFA6fki2xFrHGew==",
+      "requires": {
+        "@multiformats/multiaddr": "^11.0.0",
+        "is-ip": "^5.0.0"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "11.6.1",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+          "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "err-code": "^3.0.1",
+            "multiformats": "^11.0.0",
+            "uint8arrays": "^4.0.2",
+            "varint": "^6.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
       }
     },
     "@noble/ed25519": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@chainsafe/libp2p-noise": "^12.0.1",
     "@libp2p/mplex": "^8.0.4",
     "@libp2p/peer-id-factory": "^2.0.4",
+    "@multiformats/uri-to-multiaddr": "^7.0.0",
     "cf-libp2p-ws-transport": "^1.1.1",
     "events": "^3.3.0",
     "libp2p": "^0.45.9",

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -2,7 +2,6 @@
 import { createFromJSON } from '@libp2p/peer-id-factory'
 import { Miniswap, BITSWAP_PROTOCOL } from 'miniswap'
 import { multiaddr } from '@multiformats/multiaddr'
-import { WebSockets } from 'cf-libp2p-ws-transport'
 import { identifyService } from 'libp2p/identify'
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
@@ -13,41 +12,62 @@ import { createLibp2p } from 'libp2p'
 /**
  * Setup our libp2p service
  * @param {Env} env
- * @param {import('./deny.js').Blockstore} blockstore
  */
-export async function getLibp2p (env, blockstore) {
-  const listenAddr = env.LISTEN_ADDR ?? '/dns4/localhost/tcp/443/wss'
-  const peerId = await createFromJSON(JSON.parse(env.PEER_ID_JSON))
-  // rough metrics as a staring point
-  let blocks = 0
-  let bytes = 0
-  let miss = 0
-  const miniswap = new Miniswap({
-    async has (cid) {
-      return blockstore.has(cid)
-    },
-    async get (cid) {
-      const res = await blockstore.get(cid)
-      if (res) {
-        bytes += res.byteLength
-        blocks++
-      } else {
-        miss++
-      }
-      return res
-    }
-  })
-  const ws = new WebSockets()
+export async function getPeerId (env) {
+  return createFromJSON(JSON.parse(env.PEER_ID_JSON))
+}
+
+/**
+ * Setup our libp2p service
+ * @param {Env} env
+ * @param {import('./deny.js').Blockstore} blockstore
+ * @param {import('@libp2p/interface-peer-id').PeerId} peerId
+ * @param {import('cf-libp2p-ws-transport').WebSockets} transport
+ */
+export async function getLibp2p (env, blockstore, peerId, transport) {
   const libp2p = await createLibp2p({
     peerId,
-    addresses: { listen: [listenAddr] },
-    transports: [() => ws],
+    addresses: { listen: [getListenAddr(env)] },
+    transports: [() => transport],
     streamMuxers: [mplex()],
     connectionEncryption: [noise()],
     services: {
       identify: identifyService()
     }
   })
+
+  // rough metrics as a staring point
+  let blocks = 0
+  let bytes = 0
+  let miss = 0
+
+  const miniswap = new Miniswap({
+    async has (cid) {
+      try {
+        const res = await blockstore.has(cid)
+        return res
+      } catch (err) {
+        libp2p.stop()
+        throw err
+      }
+    },
+    async get (cid) {
+      try {
+        const res = await blockstore.get(cid)
+        if (res) {
+          bytes += res.byteLength
+          blocks++
+        } else {
+          miss++
+        }
+        return res
+      } catch (err) {
+        libp2p.stop()
+        throw err
+      }
+    }
+  })
+
   libp2p.addEventListener('peer:connect', (evt) => {
     const remotePeer = evt.detail
     console.log(JSON.stringify({ msg: 'peer:connect', peer: remotePeer.toString() }))
@@ -56,12 +76,31 @@ export async function getLibp2p (env, blockstore) {
     const remotePeer = evt.detail
     console.log(JSON.stringify({ msg: 'peer:disconnect', peer: remotePeer.toString(), blocks, bytes, miss }))
   })
+
   libp2p.handle(BITSWAP_PROTOCOL, miniswap.handler)
 
+  return libp2p
+}
+
+/**
+ * Setup our libp2p websocket listener
+ * @param {Env} env
+ * @param {import('cf-libp2p-ws-transport').WebSockets} transport
+ */
+export function getWebSocketListener (env, transport) {
+  const listenAddr = multiaddr(getListenAddr(env))
   // @ts-expect-error
-  const libp2pWebSocket = ws.listenerForMultiaddr(multiaddr(listenAddr))
-  if (!libp2pWebSocket) {
+  const listener = transport.listenerForMultiaddr(listenAddr)
+  if (!listener) {
     throw new Error(`No listener for provided listen address ${listenAddr}`)
   }
-  return libp2pWebSocket
+  return listener
+}
+
+/**
+ * Setup our libp2p websocket listener
+ * @param {Env} env
+ */
+export function getListenAddr (env) {
+  return env.LISTEN_ADDR ?? '/dns4/localhost/tcp/443/wss'
 }


### PR DESCRIPTION
profiling showed  the worker was spending a lot of time decoding car block batches. Removing the block batching allows me to fetch thousands of blocks without error. previously it would die with cpu/mem budget exceeded errors.

also numerous other fixes from local testing
- actually catch errors in the top level fetch try/catch where possible
- don't clone the respsonse in CachingBlockstore, it causes a warning and isn't needed
- don't retry dynamo cmd if error is too many subrequests
- show the multiaddr on the home page
- simplify the examples to expect a multiaddr

License: MIT