### PR TITLE
feat: add metrics and filter subrequest errors

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,0 +1,22 @@
+export class Metrics {
+  /** all blocks read (r2 + s3 + cache) */
+  blocks = 0
+  /** count of blocks read from R2 */
+  blocksR2 = 0
+  /** count of blocks read from S3 */
+  blocksS3 = 0
+  /** count of blocks read from Cache */
+  blocksCached = 0
+  /** total block bytes read (r2 + s3 + cache) */
+  blockBytes = 0
+  /** block bytes read from R2 */
+  blockBytesR2 = 0
+  /** block bytes read from S3 */
+  blockBytesS3 = 0
+  /** block bytes read from Cloudflare Cache */
+  blockBytesCached = 0
+  /** count of all index read operations (dynamo + cache) */
+  indexes = 0
+  /** count of indexes read from Cache */
+  indexesCached = 0
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "useUnknownInCatchVariables": true,
     "lib": ["ES2022", "DOM"],
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
- adds Metrics class for count of blocks, bytes and indexes
- re-work blockstore error handling and dont throw on subrequest errors as it's expected

e.g.

```sh
$ wrangler tail --env staging
 ⛅️ wrangler 3.3.0
------------------
Successfully created tail, expires at 2023-07-20T22:14:26Z
Connected to hoverboard-staging, waiting for logs...
GET https://hoverboard-staging.dag.haus/p2p/REDACTED - Ok @ 20/07/2023, 17:15:49
  (log) {"msg":"peer:connect","peer":"12D3KooWHZA6kRakMtwtXTQFJ9f7HKBr9ggpNxuDxLkbVH2dpB8x"}
  (log) {"msg":"peer:disconnect","peer":"12D3KooWHZA6kRakMtwtXTQFJ9f7HKBr9ggpNxuDxLkbVH2dpB8x","blocks":11,"blocksR2":11,"blocksS3":0,"blocksCached":0,"blockBytes":8594021,"blockBytesR2":8594021,"blockBytesS3":0,"blockBytesCached":0,"indexes":22,"indexesCached":0}
```

License: MIT