### PR TITLE
feat: enable yamux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-s3": "^3.370.0",
         "@aws-sdk/util-dynamodb": "^3.370.0",
         "@chainsafe/libp2p-noise": "^12.0.1",
+        "@chainsafe/libp2p-yamux": "^4.0.2",
         "@libp2p/mplex": "^8.0.4",
         "@libp2p/peer-id-factory": "^2.0.4",
         "@multiformats/uri-to-multiaddr": "^7.0.0",
@@ -1693,7 +1694,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
       "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
-      "dev": true,
       "dependencies": {
         "@libp2p/interface-connection": "^5.1.0",
         "@libp2p/interface-stream-muxer": "^4.1.2",
@@ -15764,7 +15764,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-4.0.2.tgz",
       "integrity": "sha512-p0m/4ab4JLaIQqUtxvm8bSqdt9sb0uXX8PFj1CQM1eJLeV1LxzzygaSOeLxN/5ckHCuK7q/9eb9xybvl6vz/JA==",
-      "dev": true,
       "requires": {
         "@libp2p/interface-connection": "^5.1.0",
         "@libp2p/interface-stream-muxer": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/client-s3": "^3.370.0",
     "@aws-sdk/util-dynamodb": "^3.370.0",
     "@chainsafe/libp2p-noise": "^12.0.1",
+    "@chainsafe/libp2p-yamux": "^4.0.2",
     "@libp2p/mplex": "^8.0.4",
     "@libp2p/peer-id-factory": "^2.0.4",
     "@multiformats/uri-to-multiaddr": "^7.0.0",

--- a/src/libp2p.js
+++ b/src/libp2p.js
@@ -4,6 +4,7 @@ import { Miniswap, BITSWAP_PROTOCOL } from 'miniswap'
 import { multiaddr } from '@multiformats/multiaddr'
 import { identifyService } from 'libp2p/identify'
 import { noise } from '@chainsafe/libp2p-noise'
+import { yamux } from '@chainsafe/libp2p-yamux'
 import { mplex } from '@libp2p/mplex'
 import { createLibp2p } from 'libp2p'
 
@@ -28,7 +29,7 @@ export async function getLibp2p (env, transport) {
     peerId,
     addresses: { listen: [getListenAddr(env)] },
     transports: [() => transport],
-    streamMuxers: [mplex()],
+    streamMuxers: [mplex(), yamux()],
     connectionEncryption: [noise()],
     services: {
       identify: identifyService()

--- a/src/worker.js
+++ b/src/worker.js
@@ -21,15 +21,12 @@ import { Metrics } from './metrics.js'
  * @prop {string} PEER_ID_JSON - secret stringified json peerId spec for this node
  */
 
+/** @type {ExportedHandler<Env>} */
 export default {
   /**
    * Handle requests.
    * - libp2p websocket requests hit `/p2p/:peerid` with the upgrade header set.
    * - other requests are assumed to be http
-   *
-   * @param {Request} request
-   * @param {Env} env
-   * @param {ExecutionContext} ctx
    */
   async fetch (request, env, ctx) {
     /** @type {import('@cloudflare/workers-types').WebSocket | undefined} */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": true,
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "target": "ES2022",
     "module": "ES2022",
   }


### PR DESCRIPTION
- adds yamux to the list of supported muxers
- this allows ipfs-check to verify that we have a given cid, which we use as part of our monitoring.
- ...also makes our types more accurate.

Change is deployed to staging and local ipfs-check is happier

<img width="1235" alt="Screenshot 2023-07-24 at 14 29 26" src="https://github.com/web3-storage/hoverboard/assets/58871/731b8d2a-78aa-49c1-8731-6b8af0950731">



License: MIT