### PR TITLE
feat: ship logs to loki

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -39,11 +39,11 @@ export default {
         const libp2p = await getLibp2p(env, transport, listenAddr)
         libp2p.addEventListener('peer:connect', (evt) => {
           const remotePeer = evt.detail
-          console.log(JSON.stringify({ msg: 'peer:connect', peer: remotePeer.toString() }))
+          console.log({ msg: 'peer:connect', peer: remotePeer.toString() })
         })
         libp2p.addEventListener('peer:disconnect', (evt) => {
           const remotePeer = evt.detail
-          console.log(JSON.stringify({ msg: 'peer:disconnect', peer: remotePeer.toString(), ...metrics }))
+          console.log({ msg: 'peer:disconnect', peer: remotePeer.toString(), ...metrics })
         })
         const onError = async (/** @type {Error} */ err) => {
           websocket?.close(418, err.message)
@@ -72,9 +72,7 @@ export default {
         // @ts-expect-error
         websocket.close(418, err.message)
       }
-      console.error('fetch handler error', err)
-      // @ts-expect-error
-      return new Response(err.message ?? err, { status: 500 })
+      throw err
     }
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,6 +24,9 @@ account_id = "fffa4b4363a7e5250af8357087263b3a"
 routes = [
 	{ pattern = "hoverboard-staging.dag.haus", custom_domain = true },
 ]
+tail_consumers = [
+  { service = "loki-staging" }
+]
 
 [env.staging.vars]
 DYNAMO_TABLE = 'staging-ep-v1-blocks-cars-position'
@@ -45,6 +48,9 @@ preview_id = "f4eb0eca32e14e28b643604a82e00cb3"
 account_id = "fffa4b4363a7e5250af8357087263b3a"
 routes = [
 	{ pattern = "hoverboard.dag.haus", custom_domain = true },
+]
+tail_consumers = [
+  { service = "loki-production" }
 ]
 
 [env.production.vars]


### PR DESCRIPTION
All you need to ship worker logs to loki is to add a `tail_consumers` block to your wrangler.toml
```yaml
tail_consumers = [
  { service = "loki-production" }
]
```

- adds our loki tail worker to ship off our logs by setting it in the `tail_consumers` prop in wrangler.toml
- tweaks our logging... just log the object and the loki tail worker will sort it out. Dont log errors just throw.

see: https://github.com/web3-storage/loki-tail-worker



License: MIT