### PR TITLE
chore: README says to 'npm install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Install `node` >= 18, and `wrangler` >= 3
 
 Copy `.example.dev.vars` to `.dev.vars` and set the AWS access keys vars.
 
+Run `npm install` to install package dependencies.
+
 Run `npm start` to start a local dev server
 
 ```sh
@@ -28,7 +30,7 @@ Run `example/dial.js` to make a test connection to your local dev server
 ```sh
 $ node example/dial.js /ip4/127.0.0.1/tcp/8787/ws/p2p/12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ
 Connected to hoverboard 🛹 /ip4/127.0.0.1/tcp/8787/ws/p2p/12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ
-``` 
+```
 
 Run `example/bitswap.js` to bitswap some blocks from staging, or pass your local multiaddr to try against dev.
 
@@ -36,7 +38,7 @@ Run `example/bitswap.js` to bitswap some blocks from staging, or pass your local
 $ node example/bitswap.js
 Connecting to /dns4/hoverboard-staging.dag.haus/tcp/443/wss/p2p/Qmc5vg9zuLYvDR1wtYHCaxjBHenfCNautRwCjG3n5v5fbs
 Fetching bafybeicm3skx7ps2bwkh56l3mirh3hu4hmkfttfwjkmk4cr25sxtf2jmby
-``` 
+```
 
 ## Secrets
 


### PR DESCRIPTION
Motivation:
* I forgot to do it and ran `npm start` which did `wrangler dev` and used my globally installed wrangler and led to an initially confusing error message. If this was here, I woulda run it and not gotten the momentary confuse